### PR TITLE
fix typo in zappar-environment-map remove method

### DIFF
--- a/src/camera-environment-map.ts
+++ b/src/camera-environment-map.ts
@@ -27,6 +27,6 @@ export default AFRAME.registerComponent("zappar-environment-map", {
     const system = document.querySelector("a-scene").systems["zappar-camera"] as any;
     // eslint-disable-next-line no-underscore-dangle
     system.unregisterForCallbacks(this._frameUpdate);
-    this.el.omponents.material.material.envMap.dipose();
+    this.el.components.material.material.envMap.dispose();
   },
 });


### PR DESCRIPTION
# Goal

Fix a `Uncaught TypeError: Cannot read properties of undefined (reading 'material')` error from the `zappar-environment-map` `remove` method

# Solution

Looks like there were a couple typos in `this.el.omponents.material.material.envMap.dipose()`